### PR TITLE
Add InDepthSearch on Value

### DIFF
--- a/handy_example_test.go
+++ b/handy_example_test.go
@@ -2,6 +2,7 @@ package fastjson_test
 
 import (
 	"fmt"
+
 	"github.com/valyala/fastjson"
 )
 

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -2,9 +2,10 @@ package fastjson_test
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson"
 	"log"
 	"strconv"
+
+	"github.com/valyala/fastjson"
 )
 
 func ExampleParser_Parse() {
@@ -168,4 +169,26 @@ func ExampleValue_GetStringBytes() {
 	// v[1][1] = "baz"
 	// v[1][0] = ""
 	// v.foo.bar.baz = ""
+}
+
+func ExampleValue_InDepthSearch() {
+	s := `{
+		"baz": [
+			{"foo": "bar_0"},
+			{"foo": "bar_1"}
+		]
+	}`
+	var p fastjson.Parser
+	v, err := p.Parse(s)
+	if err != nil {
+		log.Fatalf("cannot parse json: %s", err)
+	}
+	value, err := v.InDepthSearch("baz", "foo")
+	if err != nil {
+		log.Fatalf("cannot parse json: %s", err)
+	}
+	fmt.Printf("v.baz.foo = %v\n", value)
+
+	// Output:
+	// v.baz.foo = ["bar_0" "bar_1"]
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -307,6 +307,21 @@ func TestValueGetTyped(t *testing.T) {
 	}
 }
 
+func TestInDepthSearch(t *testing.T) {
+	var p Parser
+	v, err := p.Parse(`{"foo": [{"bar": "baz"},{"bar": [1, 4.2]}]}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	idv, err := v.InDepthSearch("foo", "bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(idv) != 3 {
+		t.Fatalf("unexpected value; got %v; want [baz, 1, 4.2]", idv)
+	}
+}
+
 func TestVisitNil(t *testing.T) {
 	var p Parser
 	v, err := p.Parse(`{}`)

--- a/scanner_example_test.go
+++ b/scanner_example_test.go
@@ -2,8 +2,9 @@ package fastjson_test
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson"
 	"log"
+
+	"github.com/valyala/fastjson"
 )
 
 func ExampleScanner() {


### PR DESCRIPTION
I think it's a good thing to be able to search elements into a json considering nested Objects and Arrays.

Example:
```
[
    {"foo": "bar_0"},
    {"foo": "bar_1"},
]
```

Should return ["bar_0", "bar_1"]
