### PR TITLE
add GetString function to parser.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -730,6 +730,14 @@ func (v *Value) GetStringBytes(keys ...string) []byte {
 	return s2b(v.s)
 }
 
+func (v *Value) GetString(keys ...string) string {
+	v = v.Get(keys...)
+	if v == nil || v.Type() != TypeString {
+		return nil
+	}
+	return v.s
+}
+
 // GetBool returns bool value by the given keys path.
 //
 // Array indexes may be represented as decimal numbers in keys.

--- a/parser.go
+++ b/parser.go
@@ -732,9 +732,6 @@ func (v *Value) GetStringBytes(keys ...string) []byte {
 
 func (v *Value) GetString(keys ...string) string {
 	v = v.Get(keys...)
-	if v == nil || v.Type() != TypeString {
-		return nil
-	}
 	return v.s
 }
 

--- a/parser.go
+++ b/parser.go
@@ -732,6 +732,9 @@ func (v *Value) GetStringBytes(keys ...string) []byte {
 
 func (v *Value) GetString(keys ...string) string {
 	v = v.Get(keys...)
+		if v == nil || v.Type() != TypeString {
+		return ""
+	}
 	return v.s
 }
 


### PR DESCRIPTION
А почему бы сразу стринг не возвращать, вместо того чтоб его вначале в []byte кастить?
добавил в парсер функцию GetString 