### PR TITLE
Add Value creation methods to allow marshaling

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,135 @@
+package fastjson
+
+import (
+	"strconv"
+)
+
+// NewObject returns a new Value with the parameter as its initial content.
+func (p *Parser) NewObject(m map[string]*Value) *Value {
+	o := p.c.getValue()
+	o.reset()
+	o.t = TypeObject
+	for k, v := range m {
+		kv := o.o.getKV()
+		kv.k = k
+		kv.v = v
+	}
+	return o
+}
+
+// NewObject returns a new Value with the parameter as its initial content.
+//
+// This function is slower than the Parser.NewObject for re-used Parser.
+func NewObject(m map[string]*Value) *Value {
+	o := new(Value)
+	o.t = TypeObject
+	for k, v := range m {
+		kv := o.o.getKV()
+		kv.k = k
+		kv.v = v
+	}
+	return o
+}
+
+// NewBool returns a new Value with the parameter as its initial content.
+func (p *Parser) NewBool(b bool) *Value {
+	v := p.c.getValue()
+	v.reset()
+	if b {
+		v.t = TypeTrue
+	} else {
+		v.t = TypeFalse
+	}
+	return v
+}
+
+// NewBool returns a new Value with the parameter as its initial content.
+//
+// This function is slower than the Parser.NewBool for re-used Parser.
+func NewBool(b bool) *Value {
+	v := new(Value)
+	if b {
+		v.t = TypeTrue
+	} else {
+		v.t = TypeFalse
+	}
+	return v
+}
+
+// NewArray returns a new Value with the parameter as its initial content.
+// The parameter is then owned by returned Value and must not be re-used.
+func (p *Parser) NewArray(a []*Value) *Value {
+	o := p.c.getValue()
+	o.reset()
+	o.t = TypeArray
+	o.a = a
+	return o
+}
+
+// NewArray returns a new Value with the parameter as its initial content.
+// The parameter is then owned by returned Value and must not be re-used.
+//
+// This function is slower than the Parser.NewArray for re-used Parser.
+func NewArray(a []*Value) *Value {
+	o := new(Value)
+	o.t = TypeArray
+	o.a = a
+	return o
+}
+
+// NewString returns a new Value with the parameter as its initial content.
+func (p *Parser) NewString(s string) *Value {
+	o := p.c.getValue()
+	o.reset()
+	o.t = TypeString
+	o.s = s
+	return o
+}
+
+// NewString returns a new Value with the parameter as its initial content.
+//
+// This function is slower than the Parser.NewString for re-used Parser.
+func NewString(s string) *Value {
+	o := new(Value)
+	o.t = TypeString
+	o.s = s
+	return o
+}
+
+// NewInt returns a new Value with the parameter as its initial content.
+func (p *Parser) NewInt(v int) *Value {
+	o := p.c.getValue()
+	o.reset()
+	o.t = TypeNumber
+	o.s = string(v)
+	return o
+}
+
+// NewInt returns a new Value with the parameter as its initial content.
+//
+// This function is slower than the Parser.NewInt64 for re-used Parser.
+func NewInt(v int) *Value {
+	o := new(Value)
+	o.t = TypeNumber
+	o.s = string(v)
+	return o
+}
+
+// NewFloat64 returns a new Value with the parameter as its initial content.
+func (p *Parser) NewFloat64(v float64) *Value {
+	o := p.c.getValue()
+	o.reset()
+	o.t = TypeNumber
+	o.s = strconv.FormatFloat(v, 'G', -1, 64)
+	return o
+}
+
+// NewFloat64 returns a new Value with the parameter as its initial content.
+//
+// This function is slower than the Parser.NewFloat64 for re-used Parser
+func NewFloat64(v float64) *Value {
+	o := new(Value)
+	o.t = TypeNumber
+	o.s = strconv.FormatFloat(v, 'G', -1, 64)
+	return o
+}

--- a/gen_test.go
+++ b/gen_test.go
@@ -1,0 +1,39 @@
+package fastjson
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCreateObject(t *testing.T) {
+	var p Parser
+	var pi float64 = 3.1415926535898
+	v := p.NewObject(map[string]*Value{
+		"foo":       p.NewString("bar"),
+		"bool_true": p.NewBool(true),
+		"number":    p.NewFloat64(pi),
+		"array": p.NewArray([]*Value{
+			p.NewString("hello"),
+			p.NewBool(false),
+		}),
+	})
+	s := v.MarshalTo(nil)
+	var val interface{}
+	err := json.Unmarshal(s, &val)
+	if err != nil {
+		t.Fatalf("Cannot unmarshal json: %s", err)
+	}
+	var expectedVal = map[string]interface{}{
+		"foo":       "bar",
+		"bool_true": true,
+		"number":    pi,
+		"array": []interface{}{
+			"hello",
+			false,
+		},
+	}
+	if !reflect.DeepEqual(val, expectedVal) {
+		t.Fatal("JSON result does not match expected result")
+	}
+}


### PR DESCRIPTION
I was looking for a dynamic json parser without generating go structs and found this awesome project. It also has good performance as a plus.
It seems like MarshalTo has just been implemented, which makes it possible to create json values.
There are many advantages using the same library for marshaling and unmarshaling, including reusing parts of a json object to create another json object, fewer dependencies. etc.
MarshalTo already provides a sound basis for marshaling, and here's one more piece of code to make it work.
I'll try to stay consistent with other parts of the code but correct me if necessary.
Thanks again for your hard work.