### PR TITLE
Rewriting the parser using stacks

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -25,7 +25,7 @@ type Arena struct {
 // Values previously allocated by a cannot be used after the Reset call.
 func (a *Arena) Reset() {
 	a.b = a.b[:0]
-	a.c.reset()
+	a.c = cache{}
 }
 
 // NewObject returns new empty object value.

--- a/parser_timing_test.go
+++ b/parser_timing_test.go
@@ -90,7 +90,7 @@ func benchmarkObjectGet(b *testing.B, itemsCount, lookupsCount int) {
 	b.SetBytes(int64(len(s)))
 
 	b.RunParallel(func(pb *testing.PB) {
-		p := benchPool.Get()
+		p := new(Parser)
 		for pb.Next() {
 			v, err := p.Parse(s)
 			if err != nil {
@@ -104,7 +104,6 @@ func benchmarkObjectGet(b *testing.B, itemsCount, lookupsCount int) {
 				}
 			}
 		}
-		benchPool.Put(p)
 	})
 }
 
@@ -130,7 +129,7 @@ func BenchmarkMarshalTo(b *testing.B) {
 }
 
 func benchmarkMarshalTo(b *testing.B, s string) {
-	p := benchPool.Get()
+	p := new(Parser)
 	v, err := p.Parse(s)
 	if err != nil {
 		panic(fmt.Errorf("unexpected error: %s", err))
@@ -146,7 +145,6 @@ func benchmarkMarshalTo(b *testing.B, s string) {
 			b = v.MarshalTo(b[:0])
 		}
 	})
-	benchPool.Put(p)
 }
 
 func BenchmarkParse(b *testing.B) {
@@ -212,8 +210,8 @@ func benchmarkFastJSONParse(b *testing.B, s string) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(s)))
 	b.RunParallel(func(pb *testing.PB) {
-		p := benchPool.Get()
 		for pb.Next() {
+		    p := new(Parser)
 			v, err := p.Parse(s)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))
@@ -222,7 +220,6 @@ func benchmarkFastJSONParse(b *testing.B, s string) {
 				panic(fmt.Errorf("unexpected value type; got %s; want %s", v.Type(), TypeObject))
 			}
 		}
-		benchPool.Put(p)
 	})
 }
 
@@ -230,10 +227,9 @@ func benchmarkFastJSONParseGet(b *testing.B, s string) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(s)))
 	b.RunParallel(func(pb *testing.PB) {
-		p := benchPool.Get()
 		var n int
 		for pb.Next() {
-			v, err := p.Parse(s)
+			v, err := new(Parser).Parse(s)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))
 			}
@@ -260,11 +256,8 @@ func benchmarkFastJSONParseGet(b *testing.B, s string) {
 				n++
 			}
 		}
-		benchPool.Put(p)
 	})
 }
-
-var benchPool ParserPool
 
 func benchmarkStdJSONParseMap(b *testing.B, s string) {
 	b.ReportAllocs()

--- a/parser_timing_test.go
+++ b/parser_timing_test.go
@@ -211,7 +211,7 @@ func benchmarkFastJSONParse(b *testing.B, s string) {
 	b.SetBytes(int64(len(s)))
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-		    p := new(Parser)
+			p := new(Parser)
 			v, err := p.Parse(s)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))

--- a/scanner.go
+++ b/scanner.go
@@ -26,8 +26,8 @@ type Scanner struct {
 	// v contains the last parsed JSON value.
 	v *Value
 
-	// c is used for caching JSON values.
-	c cache
+	// p is used for parsing JSON values.
+	p Parser
 }
 
 // Init initializes sc with the given s.
@@ -64,8 +64,8 @@ func (sc *Scanner) Next() bool {
 		return false
 	}
 
-	sc.c.reset()
-	v, tail, err := parseValue(sc.s, &sc.c)
+	sc.p = Parser{}
+	v, tail, err := sc.p.parseValue(sc.s)
 	if err != nil {
 		sc.err = err
 		return false

--- a/update.go
+++ b/update.go
@@ -36,9 +36,17 @@ func (v *Value) Del(key string) {
 	if v == nil {
 		return
 	}
+	if v.t == typeFreshObject {
+		v.o.kvs = append([]kv{}, v.o.kvs...)
+		v.t = TypeObject
+	}
 	if v.t == TypeObject {
 		v.o.Del(key)
 		return
+	}
+	if v.t == typeFreshArray {
+		v.a = append([]*Value{}, v.a...)
+		v.t = TypeArray
 	}
 	if v.t == TypeArray {
 		n, err := strconv.Atoi(key)
@@ -71,7 +79,8 @@ func (o *Object) Set(key string, value *Value) {
 	}
 
 	// Add new entry.
-	kv := o.getKV()
+	o.kvs = append(o.kvs, kv{})
+	kv := &o.kvs[len(o.kvs)-1]
 	kv.k = key
 	kv.v = value
 }
@@ -83,9 +92,17 @@ func (v *Value) Set(key string, value *Value) {
 	if v == nil {
 		return
 	}
+	if v.t == typeFreshObject {
+		v.o.kvs = append([]kv{}, v.o.kvs...)
+		v.t = TypeObject
+	}
 	if v.t == TypeObject {
 		v.o.Set(key, value)
 		return
+	}
+	if v.t == typeFreshArray {
+		v.a = append([]*Value{}, v.a...)
+		v.t = TypeArray
 	}
 	if v.t == TypeArray {
 		idx, err := strconv.Atoi(key)
@@ -100,6 +117,10 @@ func (v *Value) Set(key string, value *Value) {
 //
 // The value must be unchanged during v lifetime.
 func (v *Value) SetArrayItem(idx int, value *Value) {
+	if v.t == typeFreshArray {
+		v.a = append([]*Value{}, v.a...)
+		v.t = TypeArray
+	}
 	if v == nil || v.t != TypeArray {
 		return
 	}


### PR DESCRIPTION
After figuring out that the benchmark was defective, I created a new parser using the technique mentioned in #24 . 
The benchmark results without `benchPool`, which should be closer to the real performance:
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fastjson
BenchmarkParse/small/stdjson-map-4         	  500000	      3824 ns/op	  49.68 MB/s	     960 B/op	      51 allocs/op
BenchmarkParse/small/stdjson-struct-4      	 1000000	      2005 ns/op	  94.75 MB/s	     224 B/op	       4 allocs/op
BenchmarkParse/small/stdjson-empty-struct-4         	 1000000	      1420 ns/op	 133.75 MB/s	     168 B/op	       2 allocs/op
BenchmarkParse/small/fastjson-4                     	 1000000	      2046 ns/op	  92.85 MB/s	    3424 B/op	      11 allocs/op
BenchmarkParse/small/fastjson-get-4                 	  500000	      2178 ns/op	  87.21 MB/s	    3424 B/op	      11 allocs/op
BenchmarkParse/medium/stdjson-map-4                 	   50000	     23996 ns/op	  97.05 MB/s	   10195 B/op	     208 allocs/op
BenchmarkParse/medium/stdjson-struct-4              	   50000	     27107 ns/op	  85.92 MB/s	    9174 B/op	     258 allocs/op
BenchmarkParse/medium/stdjson-empty-struct-4        	  100000	     10688 ns/op	 217.90 MB/s	     280 B/op	       5 allocs/op
BenchmarkParse/medium/fastjson-4                    	  200000	      9703 ns/op	 240.01 MB/s	   17688 B/op	      54 allocs/op
BenchmarkParse/medium/fastjson-get-4                	  200000	      9814 ns/op	 237.30 MB/s	   17688 B/op	      54 allocs/op
BenchmarkParse/large/stdjson-map-4                  	    5000	    335337 ns/op	  83.85 MB/s	  210764 B/op	    2785 allocs/op
BenchmarkParse/large/stdjson-struct-4               	   10000	    140989 ns/op	 199.43 MB/s	   15617 B/op	     353 allocs/op
BenchmarkParse/large/stdjson-empty-struct-4         	   10000	    131005 ns/op	 214.63 MB/s	     280 B/op	       5 allocs/op
BenchmarkParse/large/fastjson-4                     	   10000	    122384 ns/op	 229.75 MB/s	  283200 B/op	     540 allocs/op
BenchmarkParse/large/fastjson-get-4                 	   10000	    121147 ns/op	 232.10 MB/s	  283200 B/op	     540 allocs/op
BenchmarkParse/canada/stdjson-map-4                 	      30	  39510900 ns/op	  56.97 MB/s	12260534 B/op	  392539 allocs/op
BenchmarkParse/canada/stdjson-struct-4              	      50	  40044040 ns/op	  56.21 MB/s	12260139 B/op	  392534 allocs/op
BenchmarkParse/canada/stdjson-empty-struct-4        	     200	   9637495 ns/op	 233.57 MB/s	     291 B/op	       5 allocs/op
BenchmarkParse/canada/fastjson-4                    	      20	 100080750 ns/op	  22.49 MB/s	75844145 B/op	  114252 allocs/op
BenchmarkParse/canada/fastjson-get-4                	      30	  54762833 ns/op	  41.11 MB/s	75844142 B/op	  114252 allocs/op
BenchmarkParse/citm/stdjson-map-4                   	     100	  15829930 ns/op	 109.11 MB/s	 5214145 B/op	   95402 allocs/op
BenchmarkParse/citm/stdjson-struct-4                	     200	   7847090 ns/op	 220.11 MB/s	    1993 B/op	      75 allocs/op
BenchmarkParse/citm/stdjson-empty-struct-4          	     200	   7860580 ns/op	 219.73 MB/s	     281 B/op	       5 allocs/op
BenchmarkParse/citm/fastjson-4                      	     100	  10795730 ns/op	 159.99 MB/s	17601362 B/op	   30574 allocs/op
BenchmarkParse/citm/fastjson-get-4                  	     200	  10633195 ns/op	 162.44 MB/s	17601360 B/op	   30574 allocs/op
BenchmarkParse/twitter/stdjson-map-4                	     200	   5939440 ns/op	 106.33 MB/s	 2187556 B/op	   31264 allocs/op
BenchmarkParse/twitter/stdjson-struct-4             	     500	   2821878 ns/op	 223.79 MB/s	     409 B/op	       6 allocs/op
BenchmarkParse/twitter/stdjson-empty-struct-4       	     500	   2807618 ns/op	 224.93 MB/s	     408 B/op	       6 allocs/op
BenchmarkParse/twitter/fastjson-4                   	     500	   2810480 ns/op	 224.70 MB/s	 5047840 B/op	    4729 allocs/op
BenchmarkParse/twitter/fastjson-get-4               	     500	   2816916 ns/op	 224.19 MB/s	 5047840 B/op	    4729 allocs/op
PASS
ok  	github.com/valyala/fastjson	60.703s
```
`fastjson` was even slower then `stdjson` despite claimed 15x improvement.
After rewriting the parser using stacks, the results are:
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fastjson
BenchmarkParse/small/stdjson-map-4         	  300000	      3967 ns/op	  47.89 MB/s	     960 B/op	      51 allocs/op
BenchmarkParse/small/stdjson-struct-4      	 1000000	      1979 ns/op	  95.99 MB/s	     224 B/op	       4 allocs/op
BenchmarkParse/small/stdjson-empty-struct-4         	 1000000	      1422 ns/op	 133.57 MB/s	     168 B/op	       2 allocs/op
BenchmarkParse/small/fastjson-4                     	 1000000	      1458 ns/op	 130.28 MB/s	    2576 B/op	      11 allocs/op
BenchmarkParse/small/fastjson-get-4                 	 1000000	      1585 ns/op	 119.86 MB/s	    2576 B/op	      11 allocs/op
BenchmarkParse/medium/stdjson-map-4                 	  100000	     22231 ns/op	 104.76 MB/s	   10195 B/op	     208 allocs/op
BenchmarkParse/medium/stdjson-struct-4              	   50000	     25822 ns/op	  90.19 MB/s	    9174 B/op	     258 allocs/op
BenchmarkParse/medium/stdjson-empty-struct-4        	  200000	     10289 ns/op	 226.35 MB/s	     280 B/op	       5 allocs/op
BenchmarkParse/medium/fastjson-4                    	  200000	      8781 ns/op	 265.22 MB/s	   17528 B/op	      19 allocs/op
BenchmarkParse/medium/fastjson-get-4                	  200000	      8879 ns/op	 262.29 MB/s	   17528 B/op	      19 allocs/op
BenchmarkParse/large/stdjson-map-4                  	    3000	    337614 ns/op	  83.28 MB/s	  210761 B/op	    2785 allocs/op
BenchmarkParse/large/stdjson-struct-4               	   10000	    146534 ns/op	 191.89 MB/s	   15617 B/op	     353 allocs/op
BenchmarkParse/large/stdjson-empty-struct-4         	   10000	    129590 ns/op	 216.98 MB/s	     280 B/op	       5 allocs/op
BenchmarkParse/large/fastjson-4                     	   20000	     65955 ns/op	 426.32 MB/s	  165288 B/op	      37 allocs/op
BenchmarkParse/large/fastjson-get-4                 	   20000	     65889 ns/op	 426.74 MB/s	  165288 B/op	      37 allocs/op
BenchmarkParse/canada/stdjson-map-4                 	      30	  39993266 ns/op	  56.29 MB/s	12260535 B/op	  392539 allocs/op
BenchmarkParse/canada/stdjson-struct-4              	      50	  40921580 ns/op	  55.01 MB/s	12260137 B/op	  392534 allocs/op
BenchmarkParse/canada/stdjson-empty-struct-4        	     200	   9418370 ns/op	 239.01 MB/s	     280 B/op	       5 allocs/op
BenchmarkParse/canada/fastjson-4                    	     100	  15223640 ns/op	 147.87 MB/s	25831338 B/op	      60 allocs/op
BenchmarkParse/canada/fastjson-get-4                	     100	  14208220 ns/op	 158.43 MB/s	25831338 B/op	      60 allocs/op
BenchmarkParse/citm/stdjson-map-4                   	     100	  16219920 ns/op	 106.49 MB/s	 5213919 B/op	   95401 allocs/op
BenchmarkParse/citm/stdjson-struct-4                	     200	   7732285 ns/op	 223.38 MB/s	    1993 B/op	      75 allocs/op
BenchmarkParse/citm/stdjson-empty-struct-4          	     200	   7791690 ns/op	 221.67 MB/s	     281 B/op	       5 allocs/op
BenchmarkParse/citm/fastjson-4                      	     300	   4030463 ns/op	 428.54 MB/s	 7909291 B/op	      59 allocs/op
BenchmarkParse/citm/fastjson-get-4                  	     300	   3764146 ns/op	 458.86 MB/s	 7909289 B/op	      59 allocs/op
BenchmarkParse/twitter/stdjson-map-4                	     200	   6131945 ns/op	 102.99 MB/s	 2188071 B/op	   31266 allocs/op
BenchmarkParse/twitter/stdjson-struct-4             	     500	   2844898 ns/op	 221.98 MB/s	     409 B/op	       6 allocs/op
BenchmarkParse/twitter/stdjson-empty-struct-4       	     500	   2823320 ns/op	 223.68 MB/s	     408 B/op	       6 allocs/op
BenchmarkParse/twitter/fastjson-4                   	    1000	   1084364 ns/op	 582.38 MB/s	 2359209 B/op	      49 allocs/op
BenchmarkParse/twitter/fastjson-get-4               	    1000	   1068186 ns/op	 591.20 MB/s	 2359208 B/op	      49 allocs/op
PASS
ok  	github.com/valyala/fastjson	57.055s
```
`fastjson` is still slower than original, but now it is really faster than `stdjson`, rather than.fake results obtained by parsing the exact same json value again and again.
There is no need to reuse `Parser` now since it is always reset before `Parse`. There may still room for improvement by reusing `Parser`, worth investigating later.