### PR TITLE
Recycled Parser and Scanner Pools

### DIFF
--- a/pool_recycled.go
+++ b/pool_recycled.go
@@ -17,7 +17,7 @@ type ParserPoolRecycled struct {
 // growth for structurally dissimilar JSON. 1,000 is probably a good number.
 func NewParserPoolRecycled(maxReuse int) *ParserPoolRecycled {
 	return &ParserPoolRecycled{
-		sync.Pool{New: func() interface{} { return new(ParserRecyclable) }},
+		sync.Pool{},
 		maxReuse,
 	}
 }
@@ -75,7 +75,7 @@ type ScannerPoolRecycled struct {
 // growth for structurally dissimilar JSON. 1,000 is probably a good number.
 func NewScannerPoolRecycled(maxReuse int) *ScannerPoolRecycled {
 	return &ScannerPoolRecycled{
-		sync.Pool{New: func() interface{} { return new(ScannerRecyclable) }},
+		sync.Pool{},
 		maxReuse,
 	}
 }

--- a/pool_recycled.go
+++ b/pool_recycled.go
@@ -1,0 +1,93 @@
+package fastjson
+
+import (
+	"sync"
+)
+
+// ParserPoolRecycled enables JSON Parser pooling for semi-structured JSON
+//
+// MaxReuse can be set to prevent a parser from being returned to the pool after a certain number of uses
+//
+// Without this protection, reusing a parser for unstructured JSON indefinitely may cause significant memory growth
+type ParserPoolRecycled struct {
+	sync.Pool
+	maxReuse int
+}
+
+func NewParserPoolRecycled(maxReuse int) *ParserPoolRecycled {
+	return &ParserPoolRecycled{
+		sync.Pool{New: func() interface{} { return new(ParserRecyclable) }},
+		maxReuse,
+	}
+}
+
+func (p *ParserPoolRecycled) Get() *ParserRecyclable {
+	return p.Pool.Get().(*ParserRecyclable)
+}
+
+func (p *ParserPoolRecycled) Put(cs *ParserRecyclable) {
+	if cs.n > p.maxReuse {
+		return
+	}
+	p.Pool.Put(cs)
+}
+
+// ParserRecyclable adds a counter to a Parser for use with ParserPoolRecycled
+type ParserRecyclable struct {
+	Parser
+	n int
+}
+
+func (p *ParserRecyclable) Parse(s string) (*Value, error) {
+	p.n++
+	return p.Parser.Parse(s)
+}
+
+func (p *ParserRecyclable) ParseBytes(b []byte) (*Value, error) {
+	p.n++
+	return p.Parser.ParseBytes(b)
+}
+
+// ScannerPoolRecycled enables JSON Scanner pooling for semi-structured JSON
+//
+// MaxReuse can be set to prevent a scanner from being returned to the pool after a certain number of uses
+//
+// Without this protection, reusing a scanner for unstructured JSON indefinitely may cause significant memory growth
+type ScannerPoolRecycled struct {
+	sync.Pool
+	maxReuse int
+}
+
+func NewScannerPoolRecycled(maxReuse int) *ScannerPoolRecycled {
+	return &ScannerPoolRecycled{
+		sync.Pool{New: func() interface{} { return new(ScannerRecyclable) }},
+		maxReuse,
+	}
+}
+
+func (p *ScannerPoolRecycled) Get() *ScannerRecyclable {
+	return p.Pool.Get().(*ScannerRecyclable)
+}
+
+func (p *ScannerPoolRecycled) Put(cs *ScannerRecyclable) {
+	if cs.n > p.maxReuse {
+		return
+	}
+	p.Pool.Put(cs)
+}
+
+// ScannerRecyclable adds a counter to a Scanner for use with ScannerPoolRecycled
+type ScannerRecyclable struct {
+	Scanner
+	n int
+}
+
+func (p *ScannerRecyclable) Init(s string) {
+	p.n++
+	p.Scanner.Init(s)
+}
+
+func (p *ScannerRecyclable) InitBytes(b []byte) {
+	p.n++
+	p.Scanner.InitBytes(b)
+}

--- a/pool_recycled_test.go
+++ b/pool_recycled_test.go
@@ -1,3 +1,5 @@
+// +build !race
+// The behavior of sync.Pool is not deterministic under race mode
 package fastjson
 
 import (

--- a/pool_recycled_test.go
+++ b/pool_recycled_test.go
@@ -28,6 +28,10 @@ func TestParserPoolRecycled(t *testing.T) {
 	if news != 4 {
 		t.Fatalf("Expected exactly 4 calls to Put (not %d)", news)
 	}
+	ppr = NewParserPoolRecycled(10)
+	if ppr.maxReuse != 10 {
+		t.Fatalf("Expected maxReuse to be 10 (not %d)", ppr.maxReuse)
+	}
 }
 
 func TestScannerPoolRecycled(t *testing.T) {
@@ -48,6 +52,10 @@ func TestScannerPoolRecycled(t *testing.T) {
 	if news != 4 {
 		t.Fatalf("Expected exactly 4 calls to Put (not %d)", news)
 	}
+	spr = NewScannerPoolRecycled(10)
+	if spr.maxReuse != 10 {
+		t.Fatalf("Expected maxReuse to be 10 (not %d)", spr.maxReuse)
+	}
 }
 
 func BenchmarkParserPoolRecycled(b *testing.B) {
@@ -63,9 +71,10 @@ func benchmarkParserPoolRecycled(b *testing.B, maxReuse int) {
 	ppr := NewParserPoolRecycled(maxReuse)
 	var v *Value
 	for i := b.N; i > 0; i-- {
-		var json = []byte(fmt.Sprintf(`{"%d":"test"}`, i))
+		var json = fmt.Sprintf(`{"%d":"test"}`, i)
 		pr := ppr.Get()
-		v, _ = pr.ParseBytes(json)
+		v, _ = pr.Parse(json)
+		v, _ = pr.ParseBytes([]byte(json))
 		ppr.Put(pr)
 	}
 	_ = v
@@ -84,9 +93,10 @@ func benchmarkScannerPoolRecycled(b *testing.B, maxReuse int) {
 	spr := NewScannerPoolRecycled(maxReuse)
 	var v *Value
 	for i := b.N; i > 0; i-- {
-		var json = []byte(fmt.Sprintf(`{"%d":"test","foo":"bar}`, rand.Int()))
+		var json = fmt.Sprintf(`{"%d":"test","foo":"bar}`, rand.Int())
 		sr := spr.Get()
-		sr.InitBytes(json)
+		sr.Init(json)
+		sr.InitBytes([]byte(json))
 		v = sr.Value()
 		spr.Put(sr)
 	}

--- a/pool_recycled_test.go
+++ b/pool_recycled_test.go
@@ -1,0 +1,79 @@
+package fastjson
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestParserPoolRecycled(t *testing.T) {
+	var news int
+	ppr := ParserPoolRecycled{
+		sync.Pool{New: func() interface{} { news++; return new(ParserRecyclable) }},
+		100,
+	}
+	for i := 333; i > 0; i-- {
+		v := ppr.Get()
+		ppr.Put(v)
+	}
+	if news > 4 {
+		t.Fatalf("Expected exactly 4 calls to Put (not %d)", news)
+	}
+}
+
+func TestScannerPoolRecycled(t *testing.T) {
+	var news int
+	spr := ScannerPoolRecycled{
+		sync.Pool{New: func() interface{} { news++; return new(ScannerRecyclable) }},
+		100,
+	}
+	for i := 333; i > 0; i-- {
+		v := spr.Get()
+		spr.Put(v)
+	}
+	if news > 4 {
+		t.Fatalf("Expected exactly 4 calls to Put (not %d)", news)
+	}
+}
+
+func BenchmarkParserPoolRecycled(b *testing.B) {
+	for _, n := range []int{0, 100, 10000, 1000000} {
+		b.Run(fmt.Sprintf("maxreuse_%d", n), func(b *testing.B) {
+			benchmarkParserPoolRecycled(b, n)
+		})
+	}
+}
+
+func benchmarkParserPoolRecycled(b *testing.B, maxReuse int) {
+	b.ReportAllocs()
+	spr := NewParserPoolRecycled(maxReuse)
+	var v interface{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v = spr.Get()
+			spr.Put(v.(*ParserRecyclable))
+		}
+	})
+	_ = v
+}
+
+func BenchmarkScannerPoolRecycled(b *testing.B) {
+	for _, n := range []int{0, 100, 10000, 1000000} {
+		b.Run(fmt.Sprintf("maxreuse_%d", n), func(b *testing.B) {
+			benchmarkScannerPoolRecycled(b, n)
+		})
+	}
+}
+
+func benchmarkScannerPoolRecycled(b *testing.B, maxReuse int) {
+	b.ReportAllocs()
+	spr := NewScannerPoolRecycled(maxReuse)
+	var v interface{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v = spr.Get()
+			spr.Put(v.(*ScannerRecyclable))
+		}
+	})
+	_ = v
+}

--- a/pool_recycled_test.go
+++ b/pool_recycled_test.go
@@ -1,5 +1,7 @@
 // +build !race
+
 // The behavior of sync.Pool is not deterministic under race mode
+
 package fastjson
 
 import (


### PR DESCRIPTION
I'd like to use fastjson for efficient parsing of semi-structured json, but I'm worried that parsing billions of structurally dissimilar messages using a conventional parser pool may cause unbounded memory growth. 

I came up with an idea to minimize issues arising from parser reuse for semi-structured json while still achieving most of the efficiency gains a parser pool provides. I figured other people might find it useful as well.

The MaxReuse parameter for `NewParserPoolRecycled` and `NewScannerPoolRecycled` prevents a parser from being returned to the pool after a certain number of uses.

```go
var ppr = fastjson.NewParserPoolRecycled(1000)
```

This PR doesn't change any existing files so there's no reason these types *need* to reside in the fastjson repository. I just wanted to put them someplace where people could find them easily and it seems to me that this tool is one of the best for working with unstructured and semi-structured json efficiently. Might as well support that use case and claim it as a feature of the package.

Would you be interested in adding this feature to the package?

```
$ go test . -run=PoolRecycled -bench=PoolRecycled
goos: windows
goarch: amd64
pkg: github.com/valyala/fastjson                         
BenchmarkParserPoolRecycled/maxreuse_0-12        1494205   796 ns/op   406 B/op   7 allocs/op
BenchmarkParserPoolRecycled/maxreuse_10-12       3979593   305 ns/op    73 B/op   2 allocs/op
BenchmarkParserPoolRecycled/maxreuse_1000-12     4867536   249 ns/op    40 B/op   2 allocs/op
BenchmarkParserPoolRecycled/maxreuse_10000-12    4927506   249 ns/op    39 B/op   2 allocs/op
BenchmarkScannerPoolRecycled/maxreuse_0-12       2187506   550 ns/op   248 B/op   5 allocs/op
BenchmarkScannerPoolRecycled/maxreuse_10-12      3821169   314 ns/op   117 B/op   3 allocs/op
BenchmarkScannerPoolRecycled/maxreuse_1000-12    4209991   289 ns/op   104 B/op   3 allocs/op
BenchmarkScannerPoolRecycled/maxreuse_10000-12   4202617   288 ns/op   104 B/op   3 allocs/op
PASS
ok      github.com/valyala/fastjson     12.777s
```