### PR TITLE
Add GetString function

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -819,6 +819,19 @@ func (v *Value) GetUint64(keys ...string) uint64 {
 	return fastfloat.ParseUint64BestEffort(v.s)
 }
 
+// GetString returns the string value by the given keys path.
+//
+// Array indexes may be represented as decimal numbers in keys.
+//
+// "" is returned for non-existing keys path or for invalid value type.
+func (v *Value) GetString(keys ...string) string {
+	v = v.Get(keys...)
+	if v == nil || v.Type() != TypeString {
+		return ""
+	}
+	return v.s
+}
+
 // GetStringBytes returns string value by the given keys path.
 //
 // Array indexes may be represented as decimal numbers in keys.

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -91,6 +91,9 @@ func ExampleValue_Get() {
 	vv := v.Get("foo", "0", "bar", "x")
 	fmt.Printf("foo[0].bar.x=%s\n", vv.GetStringBytes())
 
+	vv = v.Get("foo", "0", "bar", "x")
+	fmt.Printf("foo[0].bar.x=%s\n", vv.GetString())
+
 	vv = v.Get("qwe")
 	fmt.Printf("qwe=%v\n", vv.GetBool())
 
@@ -105,6 +108,7 @@ func ExampleValue_Get() {
 	fmt.Printf("foo.bar.baz[1234]=%v\n", vv)
 
 	// Output:
+	// foo[0].bar.x=434
 	// foo[0].bar.x=434
 	// qwe=true
 	// foo[1]=[null,false]
@@ -179,6 +183,29 @@ func ExampleObject_Visit() {
 	// object {"foo":1234}
 	// array [23,4,"bar"]
 	// string "foobar"
+}
+
+func ExampleValue_GetString() {
+	s := `[
+		{"foo": "bar"},
+		[123, "baz"]
+	]`
+
+	var p fastjson.Parser
+	v, err := p.Parse(s)
+	if err != nil {
+		log.Fatalf("cannot parse json: %s", err)
+	}
+	fmt.Printf("v[0].foo = %q\n", v.GetString("0", "foo"))
+	fmt.Printf("v[1][1] = %q\n", v.GetString("1", "1"))
+	fmt.Printf("v[1][0] = %q\n", v.GetString("1", "0"))
+	fmt.Printf("v.foo.bar.baz = %q\n", v.GetString("foo", "bar", "baz"))
+
+	// Output:
+	// v[0].foo = "bar"
+	// v[1][1] = "baz"
+	// v[1][0] = ""
+	// v.foo.bar.baz = ""
 }
 
 func ExampleValue_GetStringBytes() {

--- a/parser_test.go
+++ b/parser_test.go
@@ -372,6 +372,14 @@ func TestValueGetTyped(t *testing.T) {
 	if sb != nil {
 		t.Fatalf("unexpected value; got %q; want %q", sb, []byte(nil))
 	}
+	s := v.GetString("bar")
+	if s != "433" {
+		t.Fatalf("unexpected value; got %q; want %q", s, "443")
+	}
+	s = v.GetString("foo")
+	if s != "" {
+		t.Fatalf("unexpected value; got %q; want \"\"", s)
+	}
 	bv := v.GetBool("baz")
 	if !bv {
 		t.Fatalf("unexpected value; got %v; want %v", bv, true)
@@ -460,6 +468,14 @@ func TestValueGet(t *testing.T) {
 		if string(sb) != "" {
 			t.Fatalf("unexpected non-empty value: %q", sb)
 		}
+		s := v.GetString("")
+		if s != "empty-key" {
+			t.Fatalf("unexpected value for empty key; got %q; want %q", s, "empty-key")
+		}
+		s = v.GetString("empty-value")
+		if s != "" {
+			t.Fatalf("unexpected non-empty value: %q", s)
+		}
 
 		vv := v.Get("foo", "1")
 		if vv == nil {
@@ -544,6 +560,10 @@ func TestParserParse(t *testing.T) {
 		sb := v.GetStringBytes("\\\"\u1234x")
 		if string(sb) != `\fЗУ\\` {
 			t.Fatalf("unexpected string; got %q; want %q", sb, `\fЗУ\\`)
+		}
+		s := v.GetString("\\\"\u1234x")
+		if s != `\fЗУ\\` {
+			t.Fatalf("unexpected string; got %q; want %q", s, `\fЗУ\\`)
 		}
 	})
 
@@ -665,6 +685,10 @@ func TestParserParse(t *testing.T) {
 		sb := v.GetStringBytes()
 		if string(sb) != `{"foo": 123}` {
 			t.Fatalf("unexpected string value; got %q; want %q", sb, `{"foo": 123}`)
+		}
+		s := v.GetString()
+		if s != `{"foo": 123}` {
+			t.Fatalf("unexpected string value; got %q; want %q", s, `{"foo": 123}`)
 		}
 	})
 


### PR DESCRIPTION
Resolves #53

Convenience function so users don't have to do:

```go
s := string(v.GetStringBytes("key", "a", "b"))
```