### PR TITLE
Add ValidateParse, ValidateParser and ValidateScanner

### DIFF
--- a/handy.go
+++ b/handy.go
@@ -168,3 +168,31 @@ func MustParseBytes(b []byte) *Value {
 	}
 	return v
 }
+
+// ParseValidate parses while validating json string s.
+//
+// The function is slower than Parse but faster than running both Validate and Parse.
+func ValidateParse(s string) (*Value, error) {
+	var p ValidateParser
+	return p.Parse(s)
+}
+
+// ParseValidateBytes parses b containing json.
+//
+// The function is slower than ParseBytes but faster than running both ValidateBytes and ParseBytes.
+func ValidateParseBytes(b []byte) (*Value, error) {
+	var p ValidateParser
+	return p.ParseBytes(b)
+}
+
+// MustValidateParseBytes parses b containing json.
+//
+// The function panics if b cannot be parsed.
+// The function is slower than MustParseBytes but faster than running both ValidateBytes and ParseBytes.
+func MustValidateParseBytes(b []byte) *Value {
+	v, err := ValidateParseBytes(b)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/parser_timing_test.go
+++ b/parser_timing_test.go
@@ -206,6 +206,12 @@ func benchmarkParse(b *testing.B, s string) {
 	b.Run("fastjson-get", func(b *testing.B) {
 		benchmarkFastJSONParseGet(b, s)
 	})
+	b.Run("fastjson-validate-parser", func(b *testing.B) {
+		benchmarkFastJSONParseValidateParser(b, s)
+	})
+	b.Run("fastjson-validate-and-parse", func(b *testing.B) {
+		benchmarkFastJSONParseValidateAndParse(b, s)
+	})
 }
 
 func benchmarkFastJSONParse(b *testing.B, s string) {
@@ -264,7 +270,48 @@ func benchmarkFastJSONParseGet(b *testing.B, s string) {
 	})
 }
 
+func benchmarkFastJSONParseValidateAndParse(b *testing.B, s string) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(s)))
+	b.RunParallel(func(pb *testing.PB) {
+		p := benchPool.Get()
+		for pb.Next() {
+			err := Validate(s)
+			if err != nil {
+				panic(fmt.Errorf("unexpected error: %s", err))
+			}
+			v, err := p.Parse(s)
+			if err != nil {
+				panic(fmt.Errorf("unexpected error: %s", err))
+			}
+			if v.Type() != TypeObject {
+				panic(fmt.Errorf("unexpected value type; got %s; want %s", v.Type(), TypeObject))
+			}
+		}
+		benchPool.Put(p)
+	})
+}
+
+func benchmarkFastJSONParseValidateParser(b *testing.B, s string) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(s)))
+	b.RunParallel(func(pb *testing.PB) {
+		p := benchPoolValidate.Get()
+		for pb.Next() {
+			v, err := p.Parse(s)
+			if err != nil {
+				panic(fmt.Errorf("unexpected error: %s", err))
+			}
+			if v.Type() != TypeObject {
+				panic(fmt.Errorf("unexpected value type; got %s; want %s", v.Type(), TypeObject))
+			}
+		}
+		benchPoolValidate.Put(p)
+	})
+}
+
 var benchPool ParserPool
+var benchPoolValidate ValidateParserPool
 
 func benchmarkStdJSONParseMap(b *testing.B, s string) {
 	b.ReportAllocs()

--- a/pool.go
+++ b/pool.go
@@ -50,3 +50,27 @@ func (ap *ArenaPool) Get() *Arena {
 func (ap *ArenaPool) Put(a *Arena) {
 	ap.pool.Put(a)
 }
+
+// ValidateParserPool may be used for pooling ValidateParsers for similarly typed JSONs.
+type ValidateParserPool struct {
+	pool sync.Pool
+}
+
+// Get returns a Parser from pp.
+//
+// The ValidateParser must be Put to pp after use.
+func (pp *ValidateParserPool) Get() *ValidateParser {
+	v := pp.pool.Get()
+	if v == nil {
+		return &ValidateParser{}
+	}
+	return v.(*ValidateParser)
+}
+
+// Put returns p to pp.
+//
+// p and objects recursively returned from p cannot be used after p
+// is put into pp.
+func (pp *ValidateParserPool) Put(p *ValidateParser) {
+	pp.pool.Put(p)
+}

--- a/validate_parser.go
+++ b/validate_parser.go
@@ -1,0 +1,368 @@
+package fastjson
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ValidateParser validates while parsing JSON.
+//
+// ValidateParser may be re-used for subsequent parsing.
+//
+// ValidateParser cannot be used from concurrent goroutines.
+// Use per-goroutine ValidateParsers or ValidateParserPool instead.
+type ValidateParser struct {
+	// b contains working copy of the string to be parsed.
+	b []byte
+
+	// c is a cache for json values.
+	c cache
+}
+
+// Parse parses and validates s containing JSON.
+//
+// The returned value is valid until the next call to Parse*.
+//
+// Use Scanner if a stream of JSON values must be parsed and validated.
+func (p *ValidateParser) Parse(s string) (*Value, error) {
+	s = skipWS(s)
+	p.b = append(p.b[:0], s...)
+	p.c.reset()
+
+	v, tail, err := parseValidateValue(b2s(p.b), &p.c, 0)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parseValidate JSON: %s; unparsed tail: %q", err, startEndString(tail))
+	}
+	tail = skipWS(tail)
+	if len(tail) > 0 {
+		return nil, fmt.Errorf("unexpected tail: %q", startEndString(tail))
+	}
+	return v, nil
+}
+
+// ParseBytes parses and validates b containing JSON.
+//
+// The returned Value is valid until the next call to Parse*.
+//
+// Use Scanner if a stream of JSON values must be parsed and validated.
+func (p *ValidateParser) ParseBytes(b []byte) (*Value, error) {
+	return p.Parse(b2s(b))
+}
+
+func parseValidateValue(s string, c *cache, depth int) (*Value, string, error) {
+	if len(s) == 0 {
+		return nil, s, fmt.Errorf("cannot parseValidate empty string")
+	}
+	depth++
+	if depth > MaxDepth {
+		return nil, s, fmt.Errorf("too big depth for the nested JSON; it exceeds %d", MaxDepth)
+	}
+
+	if s[0] == '{' {
+		v, tail, err := parseValidateObject(s[1:], c, depth)
+		if err != nil {
+			return nil, tail, fmt.Errorf("cannot parseValidate object: %s", err)
+		}
+		return v, tail, nil
+	}
+	if s[0] == '[' {
+		v, tail, err := parseValidateArray(s[1:], c, depth)
+		if err != nil {
+			return nil, tail, fmt.Errorf("cannot parseValidate array: %s", err)
+		}
+		return v, tail, nil
+	}
+	if s[0] == '"' {
+		ss, tail, err := parseValidateRawString(s[1:])
+		if err != nil {
+			return nil, tail, fmt.Errorf("cannot parseValidate string: %s", err)
+		}
+		// Scan the string for control chars.
+		for i := 0; i < len(ss); i++ {
+			if ss[i] < 0x20 {
+				return nil, tail, fmt.Errorf("string cannot contain control char 0x%02X", ss[i])
+			}
+		}
+		v := c.getValue()
+		v.t = typeRawString
+		v.s = ss
+		return v, tail, nil
+	}
+	if s[0] == 't' {
+		if len(s) < len("true") || s[:len("true")] != "true" {
+			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+		}
+		return valueTrue, s[len("true"):], nil
+	}
+	if s[0] == 'f' {
+		if len(s) < len("false") || s[:len("false")] != "false" {
+			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+		}
+		return valueFalse, s[len("false"):], nil
+	}
+	if s[0] == 'n' {
+		if len(s) < len("null") || s[:len("null")] != "null" {
+			// Try parsing NaN
+			if len(s) >= 3 && strings.EqualFold(s[:3], "nan") {
+				v := c.getValue()
+				v.t = TypeNumber
+				v.s = s[:3]
+				return v, s[3:], nil
+			}
+			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+		}
+		return valueNull, s[len("null"):], nil
+	}
+
+	ns, tail, err := parseValidateRawNumber(s)
+	if err != nil {
+		return nil, tail, fmt.Errorf("cannot parseValidate number: %s", err)
+	}
+	v := c.getValue()
+	v.t = TypeNumber
+	v.s = ns
+	return v, tail, nil
+}
+
+func parseValidateArray(s string, c *cache, depth int) (*Value, string, error) {
+	s = skipWS(s)
+	if len(s) == 0 {
+		return nil, s, fmt.Errorf("missing ']'")
+	}
+
+	if s[0] == ']' {
+		v := c.getValue()
+		v.t = TypeArray
+		v.a = v.a[:0]
+		return v, s[1:], nil
+	}
+
+	a := c.getValue()
+	a.t = TypeArray
+	a.a = a.a[:0]
+	for {
+		var v *Value
+		var err error
+
+		s = skipWS(s)
+		v, s, err = parseValidateValue(s, c, depth)
+		if err != nil {
+			return nil, s, fmt.Errorf("cannot parseValidate array value: %s", err)
+		}
+		a.a = append(a.a, v)
+
+		s = skipWS(s)
+		if len(s) == 0 {
+			return nil, s, fmt.Errorf("unexpected end of array")
+		}
+		if s[0] == ',' {
+			s = s[1:]
+			continue
+		}
+		if s[0] == ']' {
+			s = s[1:]
+			return a, s, nil
+		}
+		return nil, s, fmt.Errorf("missing ',' after array value")
+	}
+}
+
+func parseValidateObject(s string, c *cache, depth int) (*Value, string, error) {
+	s = skipWS(s)
+	if len(s) == 0 {
+		return nil, s, fmt.Errorf("missing '}'")
+	}
+
+	if s[0] == '}' {
+		v := c.getValue()
+		v.t = TypeObject
+		v.o.reset()
+		return v, s[1:], nil
+	}
+
+	o := c.getValue()
+	o.t = TypeObject
+	o.o.reset()
+	for {
+		var err error
+		kv := o.o.getKV()
+
+		// Parse key.
+		s = skipWS(s)
+		if len(s) == 0 || s[0] != '"' {
+			return nil, s, fmt.Errorf(`cannot find opening '"" for object key`)
+		}
+		kv.k, s, err = parseValidateRawKey(s[1:])
+		if err != nil {
+			return nil, s, fmt.Errorf("cannot parseValidate object key: %s", err)
+		}
+		s = skipWS(s)
+		if len(s) == 0 || s[0] != ':' {
+			return nil, s, fmt.Errorf("missing ':' after object key")
+		}
+		s = s[1:]
+
+		// Parse value
+		s = skipWS(s)
+		kv.v, s, err = parseValidateValue(s, c, depth)
+		if err != nil {
+			return nil, s, fmt.Errorf("cannot parseValidate object value: %s", err)
+		}
+		s = skipWS(s)
+		if len(s) == 0 {
+			return nil, s, fmt.Errorf("unexpected end of object")
+		}
+		if s[0] == ',' {
+			s = s[1:]
+			continue
+		}
+		if s[0] == '}' {
+			return o, s[1:], nil
+		}
+		return nil, s, fmt.Errorf("missing ',' after object value")
+	}
+}
+
+// parseValidateRawKey is similar to parseValidateRawString, but is optimized
+// for small-sized keys without escape sequences.
+func parseValidateRawKey(s string) (string, string, error) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			// Fast path.
+			return s[:i], s[i+1:], nil
+		}
+		if s[i] == '\\' {
+			// Slow path.
+			return parseValidateRawString(s)
+		}
+	}
+	return s, "", fmt.Errorf(`missing closing '"'`)
+}
+
+func parseValidateRawString(s string) (string, string, error) {
+	// Try fast path - a string without escape sequences.
+	if n := strings.IndexByte(s, '"'); n >= 0 && strings.IndexByte(s[:n], '\\') < 0 {
+		return s[:n], s[n+1:], nil
+	}
+
+	// Slow path - escape sequences are present.
+	prs, tail, err := parseRawString(s)
+	if err != nil {
+		return prs, tail, err
+	}
+	var rs = prs
+	for {
+		n := strings.IndexByte(rs, '\\')
+		if n < 0 {
+			return prs, tail, nil
+		}
+		n++
+		if n >= len(rs) {
+			return prs, tail, fmt.Errorf("BUG: parseRawString returned invalid string with trailing backslash: %q", rs)
+		}
+		ch := rs[n]
+		rs = rs[n+1:]
+		switch ch {
+		case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+			// Valid escape sequences - see http://json.org/
+			break
+		case 'u':
+			if len(rs) < 4 {
+				return prs, tail, fmt.Errorf(`too short escape sequence: \u%s`, rs)
+			}
+			xs := rs[:4]
+			_, err := strconv.ParseUint(xs, 16, 16)
+			if err != nil {
+				return prs, tail, fmt.Errorf(`invalid escape sequence \u%s: %s`, xs, err)
+			}
+			rs = rs[4:]
+		default:
+			return prs, tail, fmt.Errorf(`unknown escape sequence \%c`, ch)
+		}
+	}
+}
+
+func parseValidateRawNumber(s string) (string, string, error) {
+	if len(s) == 0 {
+		return "", s, fmt.Errorf("zero-length number")
+	}
+	i := 0
+	/*
+	 * Validator does not Support Inf/NaN. Parser does.
+	 * Choosing not to support it in ValidateParser in order to match JSON spec and behavior of encoding/json.
+	 *
+	if len(s[i:]) >= 3 {
+		xs := s[i : i+3]
+		if strings.EqualFold(xs, "inf") || strings.EqualFold(xs, "nan") {
+			return s[:i+3], s[i+3:], nil
+		}
+	}
+	*/
+	if s[0] == '-' {
+		i++
+		if len(s) == i {
+			return "", s, fmt.Errorf("missing number after minus")
+		}
+	}
+	var j = i
+	for i < len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			break
+		}
+		i++
+	}
+	if j == i {
+		return "", s, fmt.Errorf("expecting 0..9 digit, got %c", s[0])
+	}
+	if s[j] == '0' && i - j != 1 {
+		return "", s, fmt.Errorf("unexpected number starting from 0")
+	}
+	if i >= len(s) {
+		return s[:i], s[i:], nil
+	}
+	if s[i] == '.' {
+		// Validate fractional part
+		i++
+		if len(s) == i {
+			return "", s, fmt.Errorf("missing fractional part")
+		}
+		j = i
+		for i < len(s) {
+			if s[i] < '0' || s[i] > '9' {
+				break
+			}
+			i++
+		}
+		if j == i {
+			return "", s, fmt.Errorf("expecting 0..9 digit in exponent part, got %c", s[i])
+		}
+		if len(s) == i {
+			return s[:i], s[i:], nil
+		}
+	}
+	if s[i] == 'e' || s[i] == 'E' {
+		// Validate exponent part
+		i++
+		if len(s) == i {
+			return "", s, fmt.Errorf("missing exponent part")
+		}
+		if s[i] == '-' || s[i] == '+' {
+			i++
+			if len(s) == i {
+				return "", s, fmt.Errorf("missing exponent part")
+			}
+		}
+		j = i
+		for i < len(s) {
+			if s[i] < '0' || s[i] > '9' {
+				break
+			}
+			i++
+		}
+		if j == i {
+			return "", s, fmt.Errorf("expecting 0..9 digit in exponent part, got %c", s[i])
+		}
+	}
+	return s[:i], s[i:], nil
+}

--- a/validate_scanner.go
+++ b/validate_scanner.go
@@ -1,0 +1,88 @@
+package fastjson
+
+// ValidateScanner scans a series of JSON values. Values may be delimited by whitespace.
+//
+// ValidateScanner may parse JSON lines ( http://jsonlines.org/ ).
+//
+// ValidateScanner may be re-used for subsequent parsing.
+//
+// ValidateScanner cannot be used from concurrent goroutines.
+//
+// Use Parser for parsing only a single JSON value.
+type ValidateScanner struct {
+	// b contains a working copy of json value passed to Init.
+	b []byte
+
+	// s points to the next JSON value to parse.
+	s string
+
+	// err contains the last error.
+	err error
+
+	// v contains the last parsed JSON value.
+	v *Value
+
+	// c is used for caching JSON values.
+	c cache
+}
+
+// Init initializes sc with the given s.
+//
+// s may contain multiple JSON values, which may be delimited by whitespace.
+func (sc *ValidateScanner) Init(s string) {
+	sc.b = append(sc.b[:0], s...)
+	sc.s = b2s(sc.b)
+	sc.err = nil
+	sc.v = nil
+}
+
+// InitBytes initializes sc with the given b.
+//
+// b may contain multiple JSON values, which may be delimited by whitespace.
+func (sc *ValidateScanner) InitBytes(b []byte) {
+	sc.Init(b2s(b))
+}
+
+// Next parses the next JSON value from s passed to Init.
+//
+// Returns true on success. The parsed value is available via Value call.
+//
+// Returns false either on error or on the end of s.
+// Call Error in order to determine the cause of the returned false.
+func (sc *ValidateScanner) Next() bool {
+	if sc.err != nil {
+		return false
+	}
+
+	sc.s = skipWS(sc.s)
+	if len(sc.s) == 0 {
+		sc.err = errEOF
+		return false
+	}
+
+	sc.c.reset()
+	v, tail, err := parseValidateValue(sc.s, &sc.c, 0)
+	if err != nil {
+		sc.err = err
+		return false
+	}
+
+	sc.s = tail
+	sc.v = v
+	return true
+}
+
+// Error returns the last error.
+func (sc *ValidateScanner) Error() error {
+	if sc.err == errEOF {
+		return nil
+	}
+	return sc.err
+}
+
+// Value returns the last parsed value.
+//
+// The value is valid until the Next call.
+func (sc *ValidateScanner) Value() *Value {
+	return sc.v
+}

--- a/validate_scanner_test.go
+++ b/validate_scanner_test.go
@@ -1,0 +1,39 @@
+package fastjson
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestValidateScanner(t *testing.T) {
+	var sc ValidateScanner
+
+	t.Run("success", func(t *testing.T) {
+		sc.InitBytes([]byte(`[] {} "" 123`))
+		var bb bytes.Buffer
+		for sc.Next() {
+			v := sc.Value()
+			fmt.Fprintf(&bb, "%s", v)
+		}
+		if err := sc.Error(); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		s := bb.String()
+		if s != `[]{}""123` {
+			t.Fatalf("unexpected string obtained; got %q; want %q", s, `[]{}""123`)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		sc.Init(`[] sdfdsfdf`)
+		for sc.Next() {
+		}
+		if err := sc.Error(); err == nil {
+			t.Fatalf("expecting non-nil error")
+		}
+		if sc.Next() {
+			t.Fatalf("Next must return false")
+		}
+	})
+}


### PR DESCRIPTION
Presently, users that want to validate their json before parsing need to run `Validate` and `Parse` sequentially.  
This is inefficient because the json byte array must be scanned twice.

This PR introduces a `ValidateParser` which validates as it parses.

It is less efficient than the normal parser, but much more efficient than running `Validate` and `Parse` separately.

```
BenchmarkParse/small/fastjson-12                        10067671      111.0 ns/op  1712.14 MB/s    0 B/op  0 allocs/op
BenchmarkParse/small/fastjson-validate-parser-12        10503465      109.8 ns/op  1729.86 MB/s    0 B/op  0 allocs/op
BenchmarkParse/small/fastjson-validate-and-parse-12      6553486      176.5 ns/op  1076.23 MB/s    0 B/op  0 allocs/op

BenchmarkParse/medium/fastjson-12                        1797662      639.2 ns/op  3643.68 MB/s    0 B/op  0 allocs/op
BenchmarkParse/medium/fastjson-validate-parser-12        1635453      795.7 ns/op  2927.14 MB/s    0 B/op  0 allocs/op
BenchmarkParse/medium/fastjson-validate-and-parse-12      945916     1400 ns/op    1663.97 MB/s    0 B/op  0 allocs/op

BenchmarkParse/large/fastjson-12                          121093     9001 ns/op    3123.79 MB/s    0 B/op  0 allocs/op
BenchmarkParse/large/fastjson-validate-parser-12          116598    10946 ns/op    2568.69 MB/s    0 B/op  0 allocs/op
BenchmarkParse/large/fastjson-validate-and-parse-12        57669    20630 ns/op    1362.95 MB/s    0 B/op  0 allocs/op

BenchmarkParse/canada/fastjson-12                           1072  1205458 ns/op    1867.39 MB/s    1 B/op  0 allocs/op
BenchmarkParse/canada/fastjson-validate-parser-12           1022  1151216 ns/op    1955.38 MB/s    1 B/op  0 allocs/op
BenchmarkParse/canada/fastjson-validate-and-parse-12         678  1781026 ns/op    1263.91 MB/s    2 B/op  0 allocs/op

BenchmarkParse/citm/fastjson-12                             2584   476059 ns/op    3628.13 MB/s    0 B/op  0 allocs/op
BenchmarkParse/citm/fastjson-validate-parser-12             2528   481104 ns/op    3590.09 MB/s    0 B/op  0 allocs/op
BenchmarkParse/citm/fastjson-validate-and-parse-12          1443   844153 ns/op    2046.08 MB/s    1 B/op  0 allocs/op

BenchmarkParse/twitter/fastjson-12                          6711   164653 ns/op    3835.42 MB/s  756 B/op  0 allocs/op
BenchmarkParse/twitter/fastjson-validate-parser-12          5918   192253 ns/op    3284.80 MB/s    0 B/op  0 allocs/op
BenchmarkParse/twitter/fastjson-validate-and-parse-12       3758   317174 ns/op    1991.06 MB/s    0 B/op  0 allocs/op
```

Adds the following symbols:
```go
type ValidateScanner
type ValidateParser 
type ValidateParserPool
func ValidateParse(s string) (*Value, error)
func ValidateParseBytes(b []byte) (*Value, error)
func MustValidateParseBytes(b []byte) *Value
```