### PR TITLE
escapeString compatibility with encoding/json

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -267,28 +267,35 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
-	if !hasSpecialChars(s) {
-		// Fast path - nothing to escape.
-		dst = append(dst, '"')
-		dst = append(dst, s...)
-		dst = append(dst, '"')
-		return dst
-	}
-
-	// Slow path.
-	return strconv.AppendQuote(dst, s)
-}
-
-func hasSpecialChars(s string) bool {
-	if strings.IndexByte(s, '"') >= 0 || strings.IndexByte(s, '\\') >= 0 {
-		return true
-	}
 	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 {
-			return true
+		c := s[i]
+		switch {
+		case c == 0x22:
+			// quotation mark
+			dst = append(dst, []byte{92, 34}...)
+		case c == 0x5c:
+			// reverse solidus
+			dst = append(dst, []byte{92, 92}...)
+		case c >= 0x20:
+			// default, rest are control chars
+			dst = append(dst, c)
+		case c < 0x09:
+			dst = append(dst, []byte{92, 117, 48, 48, 48 + c, 48}...)
+		case c == 0x09:
+			dst = append(dst, []byte{92, 116}...)
+		case c == 0x0a:
+			dst = append(dst, []byte{92, 110}...)
+		case c == 0x0d:
+			dst = append(dst, []byte{92, 114}...)
+		case c < 0x10:
+			dst = append(dst, []byte{92, 117, 48, 48, 87 + c, 48}...)
+		case c < 0x1a:
+			dst = append(dst, []byte{92, 117, 48, 49, 32 + c, 48}...)
+		case c < 0x20:
+			dst = append(dst, []byte{92, 117, 48, 49, 71 + c, 48}...)
 		}
 	}
-	return false
+	return dst
 }
 
 func unescapeStringBestEffort(s string) string {

--- a/parser.go
+++ b/parser.go
@@ -267,6 +267,7 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
+	dst = append(dst, 34)
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
@@ -295,6 +296,7 @@ func escapeString(dst []byte, s string) []byte {
 			dst = append(dst, []byte{92, 117, 48, 49, 71 + c, 48}...)
 		}
 	}
+	dst = append(dst, 34)
 	return dst
 }
 


### PR DESCRIPTION
Edited parser.go to only escape quotation mark (byte 34), reverse solidus (byte 92), and the control characters (bytes < 32). This makes it consistent with the marshaling in `encoding/json` (assuming one turns off HTML Escaping for the `json.Encoder`)

All the non-ASCII characters in UTF-8 are not affected (they only involve bytes > 128).

This fixes the signature verification bug mentioned in #86 

As an aside, here is some discussion from RFC4627:
```
All Unicode characters may be placed within the quotation marks except for the characters that must be escaped:
quotation mark, reverse solidus, and the control characters (U+0000 through U+001F). [...] The default encoding is UTF-8.
```