### PR TITLE
Add a check for redundant . and e in number parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -423,12 +423,24 @@ func parseRawString(s string) (string, string, error) {
 func parseRawNumber(s string) (string, string, error) {
 	// The caller must ensure len(s) > 0
 
+	dotFound := false
+	eFound := false
+
 	// Find the end of the number.
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
-		if (ch >= '0' && ch <= '9') || ch == '.' || ch == '-' || ch == 'e' || ch == 'E' || ch == '+' {
+		if (ch >= '0' && ch <= '9') || ch == '-' || ch == '+' {
 			continue
 		}
+		if ch == '.' && !dotFound {
+			dotFound = true
+			continue
+		}
+		if (ch == 'e' || ch == 'E') && !eFound {
+			eFound = true
+			continue
+		}
+
 		if i == 0 || i == 1 && (s[0] == '-' || s[0] == '+') {
 			if len(s[i:]) >= 3 {
 				xs := s[i : i+3]

--- a/parser_test.go
+++ b/parser_test.go
@@ -44,6 +44,8 @@ func TestParseRawNumber(t *testing.T) {
 		f("Inftail", "Inf", "tail")
 		f("-INF", "-INF", "")
 		f("-Inftail", "-Inf", "tail")
+		f("1.2.3.4", "1.2", ".3.4")
+		f("-12.345e67e70", "-12.345e67", "e70")
 	})
 
 	t.Run("error", func(t *testing.T) {


### PR DESCRIPTION
This PR naively fixes false positive parsing of an invalid number that contains more than one `.` or `e`.
https://github.com/valyala/fastjson/issues/88#issuecomment-1413818799

```go
package main

import (
	"fmt"

	"github.com/valyala/fastjson"
)

func main() {
	v, err := fastjson.ParseBytes([]byte(`[127.0.0.1]`))
	if err != nil {
		fmt.Println("failed:", err.Error())
	} else {
		fmt.Println("passed:", v.Type())
	}

	err = fastjson.ValidateBytes([]byte(`[127.0.0.1]`))
	if err != nil {
		fmt.Println("validation failed:", err.Error())
	}

	// Output:
	// passed: array
	// validation failed: cannot parse JSON: cannot parse array: missing ',' after array value; unparsed tail: ".0.1]"
}
```