### PR TITLE
Reduced slice allocations in parser cache

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -63,27 +63,29 @@ func (c *cache) reset() {
 	c.vs = c.vs[:0]
 }
 
+const preAllocatedCacheSize = 409 // calculated as 32768 / unsafe.SizeOf(Value)
+
 func (c *cache) getValue() *Value {
-	l := len(c.vs) - 1
-	needExt := l < 0 || cap(c.vs[l]) == len(c.vs[l])
+	last := len(c.vs) - 1
+	needExt := last < 0 || cap(c.vs[last]) == len(c.vs[last])
 	for {
 		if needExt {
 			if cap(c.vs) > len(c.vs) {
 				c.vs = c.vs[:len(c.vs)+1]
 			} else {
-				c.vs = append(c.vs, make([]Value, 0, 32768))
+				c.vs = append(c.vs, make([]Value, 0, preAllocatedCacheSize))
 			}
-			l = len(c.vs) - 1
+			last = len(c.vs) - 1
 			needExt = false
 		}
-		if cap(c.vs[l]) > len(c.vs[l]) {
-			c.vs[l] = c.vs[l][:len(c.vs[l])+1]
+		if cap(c.vs[last]) > len(c.vs[last]) {
+			c.vs[last] = c.vs[last][:len(c.vs[last])+1]
 		} else {
 			needExt = true
 			continue
 		}
 		// Do not reset the value, since the caller must properly init it.
-		return &c.vs[l][len(c.vs[l])-1]
+		return &c.vs[last][len(c.vs[last])-1]
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -98,21 +98,32 @@ func (c *cache) getValue() *Value {
 		addNext = true
 	}
 	if addNext {
-		nextSize := len(c.vs)
-		if nextSize*2 < macAllocatedCacheSize {
-			nextSize *= 2
-		} else {
-			nextSize = macAllocatedCacheSize
-		}
-		readSrc = &cache{
-			vs: make([]Value, 1, nextSize),
-		}
-		if c.lt != nil {
-			c.lt.nx = readSrc
+		switch {
+		case c.lt != nil && c.lt.nx != nil:
 			c.lt = c.lt.nx
-		} else {
-			c.nx = readSrc
+			readSrc = c.lt
+			readSrc.vs = readSrc.vs[:1]
+		case c.lt == nil && c.nx != nil:
 			c.lt = c.nx
+			readSrc = c.lt
+			readSrc.vs = readSrc.vs[:1]
+		default:
+			nextSize := len(c.vs)
+			if nextSize*2 < macAllocatedCacheSize {
+				nextSize *= 2
+			} else {
+				nextSize = macAllocatedCacheSize
+			}
+			readSrc = &cache{
+				vs: make([]Value, 1, nextSize),
+			}
+			if c.lt != nil {
+				c.lt.nx = readSrc
+				c.lt = c.lt.nx
+			} else {
+				c.nx = readSrc
+				c.lt = c.nx
+			}
 		}
 	}
 	// Do not reset the value, since the caller must properly init it.

--- a/parser.go
+++ b/parser.go
@@ -64,10 +64,7 @@ func (c *cache) reset() {
 	c.vs = c.vs[:0]
 }
 
-const (
-	minPreAllocatedCacheSize = 256
-	maxPreAllocatedCacheSize = 32768
-)
+const preAllocatedCacheSize = 32768
 
 func (c *cache) getValue() *Value {
 	last := len(c.vs) - 1
@@ -77,12 +74,7 @@ func (c *cache) getValue() *Value {
 			if cap(c.vs) > len(c.vs) {
 				c.vs = c.vs[:len(c.vs)+1]
 			} else {
-				c.allocated++
-				newSz := minPreAllocatedCacheSize * c.allocated
-				if newSz > maxPreAllocatedCacheSize {
-					newSz = maxPreAllocatedCacheSize
-				}
-				c.vs = append(c.vs, make([]Value, 0, newSz))
+				c.vs = append(c.vs, make([]Value, 0, preAllocatedCacheSize))
 			}
 			last = len(c.vs) - 1
 			needExt = false


### PR DESCRIPTION
We use fastjson in our project and recently I found an unpleasant issue when processing huge json files (we have 25 megabytes and more than 300 thousand elements in the array):
when cache.vs reaches its limit and performs memory reallocation, if the GC fails to clean up the memory in time, we experience a sharp spike in memory usage graphs.

The funniest part is that we barely noticed this, because our application kept crashing with OOM, so we had to temporarily disable the limits for testing.

After working with pprof for a while, I found where the most memory allocations are happening and worked on improvements. I tried several options and this one turned out to be the most efficient, as shown by the tests in our environment.

If you don't accept this pull request, it's okay, then we'll just continue using our fork.

Thank you.