### PR TITLE
Add ability to set values by path like []any{"k", 0, "k2"}

### DIFF
--- a/path.go
+++ b/path.go
@@ -1,0 +1,106 @@
+package fastjson
+
+// Path represents a path to a value in a JSON object.
+// It is a sequence of keys (strings) and indexes (integers).
+// For example, Path{"a", 0, "b"} for accessing field 'b' of the first element of array field 'a'.
+type Path []interface{}
+
+// SetP sets a value at the specified path.
+// If the path does not exist, it will be created.
+// special case: if path contains -1 as an index, a new array item will be added.
+func (v *Value) SetP(path Path, value *Value) {
+	if v == nil || len(path) == 0 {
+		return
+	}
+
+	key := path[0]
+	rest := path[1:]
+
+	switch v.t {
+	case TypeObject:
+		k, ok := key.(string)
+		if !ok {
+			return
+		}
+		if len(rest) == 0 {
+			v.o.Set(k, value)
+			return
+		}
+		child := v.o.Get(k)
+		if child == nil {
+			if _, nextIsInt := rest[0].(int); nextIsInt {
+				child = &Value{t: TypeArray} // create new array
+			} else {
+				child = &Value{t: TypeObject} // create new object
+			}
+			v.o.Set(k, child)
+		}
+		v.o.Get(k).SetP(rest, value) // recursive call
+
+	case TypeArray:
+		idx, ok := key.(int)
+		if !ok {
+			return
+		}
+		if idx == -1 {
+			idx = len(v.a)
+		}
+		if len(rest) == 0 {
+			v.SetArrayItem(idx, value)
+			return
+		}
+		if idx >= len(v.a) { // index out of range, create new empty arr/obj
+			var child *Value
+			if _, nextIsInt := rest[0].(int); nextIsInt {
+				child = &Value{t: TypeArray} // create new array
+			} else {
+				child = &Value{t: TypeObject} // create new object
+			}
+			v.SetArrayItem(idx, child)
+		}
+		v.a[idx].SetP(rest, value) // recursive call
+	}
+}
+
+func (v *Value) GetP(path Path) *Value {
+	if v == nil || len(path) == 0 {
+		return nil
+	}
+
+	key := path[0]
+	rest := path[1:]
+
+	switch v.t {
+	case TypeObject:
+		k, ok := key.(string)
+		if !ok {
+			return nil
+		}
+		if len(rest) == 0 {
+			return v.o.Get(k)
+		}
+		child := v.o.Get(k)
+		if child == nil {
+			return nil
+		}
+		return child.GetP(rest) // recursive call
+
+	case TypeArray:
+		idx, ok := key.(int)
+		if !ok {
+			return nil
+		}
+		if idx < 0 || idx >= len(v.a) {
+			return nil
+		}
+		if len(rest) == 0 {
+			return v.a[idx]
+		}
+		child := v.a[idx]
+		if child == nil {
+			return nil
+		}
+		return child.GetP(rest) // recursive call
+	}
+	return nil
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,145 @@
+package fastjson
+
+import (
+	"testing"
+)
+
+func TestValue_SetP(t *testing.T) {
+	t.Run("Update existing nested value", func(t *testing.T) {
+		v := MustParse(`{"a": {"b": 1}}`)
+		v.SetP(Path{"a", "b"}, MustParse("2"))
+		if val := v.Get("a").Get("b").GetInt(); val != 2 {
+			t.Fatalf("expected 2, got %v", val)
+		}
+	})
+
+	t.Run("Set new top-level key", func(t *testing.T) {
+		v := MustParse(`{}`)
+		v.Set("z", MustParse(`111`))
+		if val := v.Get("z").GetInt(); val != 111 {
+			t.Fatalf("expected 111, got %v", val)
+		}
+	})
+
+	t.Run("Set new nested key in object", func(t *testing.T) {
+		v := MustParse(`{"a": {}}`)
+		v.SetP(Path{"a", "bb"}, MustParse(`555`))
+		if val := v.Get("a").Get("bb").GetInt(); val != 555 {
+			t.Fatalf("expected 555, got %v", val)
+		}
+	})
+
+	t.Run("Set deep nested key with intermediate objects", func(t *testing.T) {
+		v := MustParse(`{"a": {}}`)
+		v.SetP(Path{"a", "sub", "subsub", "s3"}, MustParse(`666`))
+		if val := v.Get("a").Get("sub").Get("subsub").Get("s3").GetInt(); val != 666 {
+			t.Fatalf("expected 666, got %v", val)
+		}
+	})
+
+	t.Run("Update array element by index", func(t *testing.T) {
+		v := MustParse(`{"arr": [99]}`)
+		v.SetP(Path{"arr", 0}, MustParse(`111`))
+		if val := v.Get("arr").Get("0").GetInt(); val != 111 {
+			t.Fatalf("expected 111, got %v", val)
+		}
+	})
+
+	t.Run("Add element to empty array", func(t *testing.T) {
+		v := MustParse(`{"arr": []}`)
+		v.SetP(Path{"arr", 0}, MustParse(`111`))
+		if val := v.Get("arr").Get("0").GetInt(); val != 111 {
+			t.Fatalf("expected 111, got %v", val)
+		}
+	})
+
+	// Test attempting to set nested value in non-array (operation should have no effect).
+	t.Run("Attempt to set nested value in non-array", func(t *testing.T) {
+		v := MustParse(`{"a":[0]}`)
+		v.SetP(Path{"a", 0, 0}, MustParse(`222`))
+		if v.String() != `{"a":[0]}` {
+			t.Fatalf("expected unchanged value, got %s", v.String())
+		}
+	})
+
+	// Test creating missing null values in array when setting element beyond current length.
+	t.Run("Create missing null values in array", func(t *testing.T) {
+		v := MustParse(`{"a":[0]}`)
+		v.SetP(Path{"a", 2}, MustParse(`111`))
+		if val := v.Get("a").Get("0").GetInt(); val != 0 {
+			t.Fatalf("expected 0 at index 0, got %v", val)
+		}
+		if typ := v.Get("a").Get("1").Type(); typ != TypeNull {
+			t.Fatalf("expected null at index 1, got type %v", typ)
+		}
+		if val := v.Get("a").Get("2").GetInt(); val != 111 {
+			t.Fatalf("expected 111 at index 2, got %v", val)
+		}
+	})
+
+	// Test -1 index to append to array.
+	t.Run("Append to array with -1 index", func(t *testing.T) {
+		v := MustParse(`[]`)
+		v.SetP(Path{-1}, MustParse(`111`))
+		if v.String() != `[111]` {
+			t.Fatalf("expected appended value, got %s", v.String())
+		}
+
+		v = MustParse(`{"a":[0]}`)
+		v.SetP(Path{"a", -1}, MustParse(`111`))
+		if v.String() != `{"a":[0,111]}` {
+			t.Fatalf("expected appended value, got %s", v.String())
+		}
+	})
+
+	// Test -1 index in the middle of the path.
+	t.Run("Append to array with -1 index in the middle of the path", func(t *testing.T) {
+		v := MustParse(`{}`)
+		v.SetP(Path{"a", -1, "aa"}, MustParse(`1`))
+		v.SetP(Path{"a", -1, "bb"}, MustParse(`2`))
+		v.SetP(Path{"a", -1, "cc"}, MustParse(`3`))
+		if v.String() != `{"a":[{"aa":1},{"bb":2},{"cc":3}]}` {
+			t.Fatalf("expected appended value, got %s", v.String())
+		}
+	})
+}
+
+func TestValue_GetP(t *testing.T) {
+	t.Run("Get existing nested value", func(t *testing.T) {
+		v := MustParse(`{"a": {"b": 1}}`)
+		if val := v.GetP(Path{"a", "b"}).GetInt(); val != 1 {
+			t.Fatalf("expected 1, got %v", val)
+		}
+	})
+
+	t.Run("Get non-existing nested value", func(t *testing.T) {
+		v := MustParse(`{"a": {"b": 1}}`)
+		if val := v.GetP(Path{"a", "c"}); val != nil {
+			t.Fatalf("expected nil, got %v", val)
+		}
+	})
+
+	t.Run("Get value from array by index", func(t *testing.T) {
+		v := MustParse(`[1,2,3,[4,5,6,[7,8,9]]]`)
+		if val := v.GetP(Path{3, 2}).GetInt(); val != 6 {
+			t.Fatalf("expected 6, got %v", val)
+		}
+		if val := v.GetP(Path{3, 3, 1}).GetInt(); val != 8 {
+			t.Fatalf("expected 8, got %v", val)
+		}
+	})
+
+	t.Run("Get from array inside object", func(t *testing.T) {
+		v := MustParse(`{"a": [1,2,3]}`)
+		if val := v.GetP(Path{"a", 1}).GetInt(); val != 2 {
+			t.Fatalf("expected 2, got %v", val)
+		}
+	})
+
+	t.Run("Get from object inside array", func(t *testing.T) {
+		v := MustParse(`[{"a":1},{"b":2}]`)
+		if val := v.GetP(Path{1, "b"}).GetInt(); val != 2 {
+			t.Fatalf("expected 2, got %v", val)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds Value.SetP and Value.GetP methods.

### Motivation
These methods provide a straightforward way to access and modify deeply nested JSON structures without the need for repetitive checks and object creations. They enhance the usability of the fastjson package by allowing developers to work with JSON paths directly.

### Usage Intended:

* `SetP(path Path, value *Value)`: Sets a value at the specified JSON path, creating any necessary intermediate objects or arrays along the way.

* `GetP(path Path) *Value`: Retrieves a value from the specified JSON path, returning `nil` if any part of the path does not exist.

#### Example
```go
v := fastjson.MustParse(`{"a": {"b": 1}}`)

// Set a nested value
v.SetP(Path{"a", "b"}, fastjson.MustParse("2"))
// Now v is: {"a": {"b": 2}}

// Get a nested value
val := v.GetP(Path{"a", "b"}).GetInt()
// val == 2

// Set a new nested value, creating intermediate objects
v.SetP(Path{"a", "c", "d"}, fastjson.MustParse(`"hello"`))
// Now v is: {"a": {"b": 2, "c": {"d": "hello"}}}

```