### PR TITLE
Resetting the Arena before putting it to the ArenaPool

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -48,5 +48,6 @@ func (ap *ArenaPool) Get() *Arena {
 //
 // a and objects created by a cannot be used after a is put into ap.
 func (ap *ArenaPool) Put(a *Arena) {
+	a.Reset()
 	ap.pool.Put(a)
 }


### PR DESCRIPTION
The way the Arena is meant to be used as highlighted [here](https://github.com/valyala/fastjson/blob/93f67d942133e9d219dbbae7a541433f8bbbe7c4/arena.go#L9-L14)

```
 1) Construct Values via the Arena and Value.Set* calls.
 2) Marshal the constructed Values with Value.MarshalTo call.
 3) Reset all the constructed Values at once by Arena.Reset call.
 4) Go to 1 and re-use the Arena.
```

When using the ArenaPool, someone would have then to manually reset the Arena before returning it to the Pool
```
var pool fastjson.ArenaPool
....

func foo() {
....
  arena := pool.Get()
  defer func() {
    arena.Reset()
    pool.Put(arena)
  }
...
}
```
Which results in many repetitive code or worse, using the API wrong  (e.g. putting the Arena in the ArenaPool before resetting it)

Looking at the description of the ArenaPool#Put method as described [here](https://github.com/valyala/fastjson/blob/93f67d942133e9d219dbbae7a541433f8bbbe7c4/pool.go#L47-L49)
it makes me think that the intention was that `ArenaPool#Put` would reset the pool