### PR TITLE
Allow use b2s and s2b function with old and new go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: 
+          - stable
+          - oldstable
+          - 1.20.x
+          - 1.19.x
+          - 1.12.x
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - run: go version
+      - run: go test -race ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,14 @@ jobs:
           - 1.21.x 
           - 1.20.x
           - 1.19.x
+          - 1.18.x
+          - 1.17.x
+          - 1.16.x
+          - 1.15.x
+          - 1.14.x
+          - 1.13.x
           - 1.12.x
+          - 1.10.x
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - allow-use-b2s-and-s2b-function-with-old-and-new-formats
   pull_request:
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
           - 1.14.x
           - 1.13.x
           - 1.12.x
-          - 1.10.x
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,27 @@ jobs:
         go-version: 
           - stable
           - oldstable
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - run: go version
+      - run: go test -race ./...
+  backward_compatibility:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.22.x
+          - 1.21.x 
           - 1.20.x
           - 1.19.x
           - 1.12.x
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - run: go version
-      - run: go test -race ./...
+      - run: go test -shuffle=on ./...
+      - run: go test -race -shuffle=on ./...
   backward_compatibility:
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - allow-use-b2s-and-s2b-function-with-old-and-new-formats
   pull_request:
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 tags
+*.pprof
+.idea
+.vscode
+.DS_Store
+vendor/
+testdata/fuzz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.10.x
+  - 1.12.x
 
 script:
   # build test for supported platforms

--- a/arena.go
+++ b/arena.go
@@ -8,10 +8,10 @@ import (
 //
 // Typical Arena lifecycle:
 //
-//     1) Construct Values via the Arena and Value.Set* calls.
-//     2) Marshal the constructed Values with Value.MarshalTo call.
-//     3) Reset all the constructed Values at once by Arena.Reset call.
-//     4) Go to 1 and re-use the Arena.
+//  1. Construct Values via the Arena and Value.Set* calls.
+//  2. Marshal the constructed Values with Value.MarshalTo call.
+//  3. Reset all the constructed Values at once by Arena.Reset call.
+//  4. Go to 1 and re-use the Arena.
 //
 // It is unsafe calling Arena methods from concurrent goroutines.
 // Use per-goroutine Arenas or ArenaPool instead.

--- a/b2s_new.go
+++ b/b2s_new.go
@@ -1,4 +1,5 @@
 //go:build go1.20
+// +build go1.20
 
 package fastjson
 

--- a/b2s_new.go
+++ b/b2s_new.go
@@ -1,0 +1,11 @@
+//go:build go1.20
+
+package fastjson
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+func b2s(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/b2s_new.go
+++ b/b2s_new.go
@@ -1,5 +1,5 @@
-//go:build go1.20
-// +build go1.20
+//go:build go1.21
+// +build go1.21
 
 package fastjson
 

--- a/b2s_old.go
+++ b/b2s_old.go
@@ -1,5 +1,5 @@
-//go:build !go1.20
-// +build !go1.20
+//go:build !go1.21
+// +build !go1.21
 
 package fastjson
 

--- a/b2s_old.go
+++ b/b2s_old.go
@@ -1,4 +1,5 @@
 //go:build !go1.20
+// +build !go1.20
 
 package fastjson
 

--- a/b2s_old.go
+++ b/b2s_old.go
@@ -1,0 +1,14 @@
+//go:build !go1.20
+
+package fastjson
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
+func b2s(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,5 @@ Package fastjson provides fast JSON parsing.
 Arbitrary JSON may be parsed by fastjson without the need for creating structs
 or for generating go code. Just parse JSON and get the required fields with
 Get* functions.
-
 */
 package fastjson

--- a/fastfloat/parse.go
+++ b/fastfloat/parse.go
@@ -507,5 +507,7 @@ func Parse(s string) (float64, error) {
 	return 0, fmt.Errorf("cannot parse float64 from %q", s)
 }
 
-var inf = math.Inf(1)
-var nan = math.NaN()
+var (
+	inf = math.Inf(1)
+	nan = math.NaN()
+)

--- a/fastfloat/parse.go
+++ b/fastfloat/parse.go
@@ -240,9 +240,7 @@ func ParseBestEffort(s string) float64 {
 	}
 	if i <= j && s[i] != '.' {
 		s = s[i:]
-		if strings.HasPrefix(s, "+") {
-			s = s[1:]
-		}
+		s = strings.TrimPrefix(s, "+")
 		// "infinity" is needed for OpenMetrics support.
 		// See https://github.com/OpenObservability/OpenMetrics/blob/master/OpenMetrics.md
 		if strings.EqualFold(s, "inf") || strings.EqualFold(s, "infinity") {
@@ -398,9 +396,7 @@ func Parse(s string) (float64, error) {
 	}
 	if i <= j && s[i] != '.' {
 		ss := s[i:]
-		if strings.HasPrefix(ss, "+") {
-			ss = ss[1:]
-		}
+		ss = strings.TrimPrefix(ss, "+")
 		// "infinity" is needed for OpenMetrics support.
 		// See https://github.com/OpenObservability/OpenMetrics/blob/master/OpenMetrics.md
 		if strings.EqualFold(ss, "inf") || strings.EqualFold(ss, "infinity") {

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package fastjson

--- a/handy_example_test.go
+++ b/handy_example_test.go
@@ -2,6 +2,7 @@ package fastjson_test
 
 import (
 	"fmt"
+
 	"github.com/valyala/fastjson"
 )
 

--- a/parser.go
+++ b/parser.go
@@ -2,10 +2,11 @@ package fastjson
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson/fastfloat"
 	"strconv"
 	"strings"
 	"unicode/utf16"
+
+	"github.com/valyala/fastjson/fastfloat"
 )
 
 // Parser parses JSON.

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -2,9 +2,10 @@ package fastjson_test
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson"
 	"log"
 	"strconv"
+
+	"github.com/valyala/fastjson"
 )
 
 func ExampleParser_Parse() {

--- a/parser_test.go
+++ b/parser_test.go
@@ -349,7 +349,7 @@ func TestValueGetTyped(t *testing.T) {
 	}
 	un64 = v.GetUint64("bar")
 	if n != 0 {
-		t.Fatalf("unexpected non-zero value; got %d", n64)
+		t.Fatalf("unexpected non-zero value; got %d", un64)
 	}
 	f := v.GetFloat64("foo")
 	if f != 123.0 {

--- a/parser_test.go
+++ b/parser_test.go
@@ -144,7 +144,6 @@ func TestParseRawString(t *testing.T) {
 		f(`"x\\y"tail`, `x\\y`, "tail")
 		f(`"\\\"й\n\"я"tail`, `\\\"й\n\"я`, "tail")
 		f(`"\\\\\\\\"tail`, `\\\\\\\\`, "tail")
-
 	})
 
 	t.Run("error", func(t *testing.T) {
@@ -1197,7 +1196,6 @@ func TestParserParse(t *testing.T) {
 		if ss != s {
 			t.Fatalf("unexpected string representation for object; got\n%q; want\n%q", ss, s)
 		}
-
 	})
 }
 

--- a/s2b_new.go
+++ b/s2b_new.go
@@ -1,4 +1,5 @@
 //go:build go1.20
+// +build go1.20
 
 package fastjson
 

--- a/s2b_new.go
+++ b/s2b_new.go
@@ -1,0 +1,10 @@
+//go:build go1.20
+
+package fastjson
+
+import "unsafe"
+
+// s2b converts string to a byte slice without memory allocation.
+func s2b(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/s2b_new.go
+++ b/s2b_new.go
@@ -1,5 +1,5 @@
-//go:build go1.20
-// +build go1.20
+//go:build go1.21
+// +build go1.21
 
 package fastjson
 

--- a/s2b_old.go
+++ b/s2b_old.go
@@ -1,5 +1,5 @@
-//go:build !go1.20
-// +build !go1.20
+//go:build !go1.21
+// +build !go1.21
 
 package fastjson
 

--- a/s2b_old.go
+++ b/s2b_old.go
@@ -1,0 +1,21 @@
+//go:build !go1.20
+
+package fastjson
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// s2b converts string to a byte slice without memory allocation.
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
+func s2b(s string) (b []byte) {
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	return b
+}

--- a/s2b_old.go
+++ b/s2b_old.go
@@ -1,4 +1,5 @@
 //go:build !go1.20
+// +build !go1.20
 
 package fastjson
 

--- a/scanner_example_test.go
+++ b/scanner_example_test.go
@@ -2,8 +2,9 @@ package fastjson_test
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson"
 	"log"
+
+	"github.com/valyala/fastjson"
 )
 
 func ExampleScanner() {

--- a/util.go
+++ b/util.go
@@ -1,23 +1,5 @@
 package fastjson
 
-import (
-	"reflect"
-	"unsafe"
-)
-
-func b2s(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
-}
-
-func s2b(s string) (b []byte) {
-	strh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh.Data = strh.Data
-	sh.Len = strh.Len
-	sh.Cap = strh.Len
-	return b
-}
-
 const maxStartEndStringLen = 80
 
 func startEndString(s string) string {

--- a/validate.go
+++ b/validate.go
@@ -215,7 +215,7 @@ func validateString(s string) (string, string, error) {
 		switch ch {
 		case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
 			// Valid escape sequences - see http://json.org/
-			break
+			continue
 		case 'u':
 			if len(rs) < 4 {
 				return rs, tail, fmt.Errorf(`too short escape sequence: \u%s`, rs)

--- a/validate_test.go
+++ b/validate_test.go
@@ -48,7 +48,7 @@ func TestValidateNumberZeroLen(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	var tests = []string{
+	tests := []string{
 		"",
 		"   ",
 		" z",


### PR DESCRIPTION
I note that this project is using and old version of s2b and b2s

Like on fasthttp last stable version v1.62.0, I add two versions of each function based on go version (I just copy the files from fasthttp).

After include the the old build tag format `// +build` I manage to run the unit tests in *all* environments except go 1.20.x, I did not a nice way to handle it, so I decided to switch the build version to 1.21 instead the original 1.20

This project was designed to run on go 1.12 based on go.mod, so I decided to not change it. I don't know if the travis ci is still available so I also

1. I add an .github/workflows/test.yml based on fasthttp, but running the shuffle tests on stable and oldstable (1.24.x and 1.23.x) while I just run the normal tests with race condition detector for all versions of go between 1.22.x and 1.12.x (maybe it is too much) and I decided to stick with only ubuntu for this cases (some os images does not work with certain versions, I have no time to improve it)
2. I try to fix the current .travis.yml since the tests fail on 1.10.x 
3. I perform small fixes in the code (unused variables, godoc, etc)

The last two items can be extracted in a second pull request if needed

To be honnest, a better approach could be switch the go mod to support explicit go 1.23 (like fasthttp on master) and update the code to use for range integer loops (introduced on go 1.22) and perhaps switch from `interface{}` to `any` (introduced on go 1.18)