### PR TITLE
Treat nil values as null in SetArrayItem

### DIFF
--- a/arena_test.go
+++ b/arena_test.go
@@ -63,13 +63,15 @@ func testArena(a *Arena) error {
 	aa := a.NewArray()
 	aa.SetArrayItem(0, s)
 	aa.Set("1", ni)
+	aa.SetArrayItem(2, nil)
+	aa.SetArrayItem(3, a.NewNull())
 	o.Set("a", aa)
 	obj := a.NewObject()
 	obj.Set("s", s)
 	o.Set("obj", obj)
 
 	str := o.String()
-	strExpected := `{"nil1":null,"nil2":null,"false":false,"true":true,"ni":123,"nf":1.23,"ns":34.43,"str1":"foo","str2":"xx","a":["foo",123],"obj":{"s":"foo"}}`
+	strExpected := `{"nil1":null,"nil2":null,"false":false,"true":true,"ni":123,"nf":1.23,"ns":34.43,"str1":"foo","str2":"xx","a":["foo",123,null,null],"obj":{"s":"foo"}}`
 	if str != strExpected {
 		return fmt.Errorf("unexpected json\ngot\n%s\nwant\n%s", str, strExpected)
 	}

--- a/update.go
+++ b/update.go
@@ -106,5 +106,8 @@ func (v *Value) SetArrayItem(idx int, value *Value) {
 	for idx >= len(v.a) {
 		v.a = append(v.a, valueNull)
 	}
+	if value == nil {
+		value = valueNull
+	}
 	v.a[idx] = value
 }


### PR DESCRIPTION
This update aligns the behavior with the [(Object).Set](https://github.com/valyala/fastjson/blob/b265b435051ec04785b66d58d8ed32951c3813c2/update.go#L59-L61) method and prevents a potential panic when a nil value is used as an array item.