### PR TITLE
skipWSSlow improve: 15.1% faster, use search table

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -4,17 +4,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"unicode/utf16"
 
 	"github.com/valyala/fastjson/fastfloat"
 )
-
-var Pool = sync.Pool{
-	New: func() any {
-		return &Parser{}
-	},
-}
 
 // Parser parses JSON.
 //

--- a/parser.go
+++ b/parser.go
@@ -2,11 +2,19 @@ package fastjson
 
 import (
 	"fmt"
-	"github.com/valyala/fastjson/fastfloat"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf16"
+
+	"github.com/valyala/fastjson/fastfloat"
 )
+
+var Pool = sync.Pool{
+	New: func() any {
+		return &Parser{}
+	},
+}
 
 // Parser parses JSON.
 //
@@ -30,6 +38,27 @@ type Parser struct {
 func (p *Parser) Parse(s string) (*Value, error) {
 	s = skipWS(s)
 	p.b = append(p.b[:0], s...)
+	p.c.reset()
+
+	v, tail, err := p.c.parseValue(b2s(p.b), 0)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse JSON: %s; unparsed tail: %q", err, startEndString(tail))
+	}
+	tail = skipWS(tail)
+	if len(tail) > 0 {
+		return nil, fmt.Errorf("unexpected tail: %q", startEndString(tail))
+	}
+	return v, nil
+}
+
+func (p *Parser) Reset() {
+	p.b = p.b[:0]
+	p.c.reset()
+}
+
+func (p *Parser) ParseNoCopy(s string) (*Value, error) {
+	s = skipWS(s)
+	p.b = s2b(s)
 	p.c.reset()
 
 	v, tail, err := p.c.parseValue(b2s(p.b), 0)

--- a/parser.go
+++ b/parser.go
@@ -103,12 +103,24 @@ func skipWS(s string) string {
 	return skipWSSlow(s)
 }
 
+var wsTable = func() [256]byte {
+	var table [256]byte
+	for _, c := range []byte{0x20, 0x0A, 0x09, 0x0D} {
+		table[c] = 1
+	}
+	return table
+}()
+
+func isWSBySearchTable(ch byte) bool {
+	return wsTable[ch] != 0
+}
+
 func skipWSSlow(s string) string {
-	if len(s) == 0 || s[0] != 0x20 && s[0] != 0x0A && s[0] != 0x09 && s[0] != 0x0D {
+	if len(s) == 0 || !isWSBySearchTable(s[0]) {
 		return s
 	}
 	for i := 1; i < len(s); i++ {
-		if s[i] != 0x20 && s[i] != 0x0A && s[i] != 0x09 && s[i] != 0x0D {
+		if !isWSBySearchTable(s[i]) {
 			return s[i:]
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -103,24 +103,20 @@ func skipWS(s string) string {
 	return skipWSSlow(s)
 }
 
-var wsTable = func() [256]byte {
-	var table [256]byte
+var wsSearchTable = func() [256]bool {
+	var table [256]bool
 	for _, c := range []byte{0x20, 0x0A, 0x09, 0x0D} {
-		table[c] = 1
+		table[c] = true
 	}
 	return table
 }()
 
-func isWSBySearchTable(ch byte) bool {
-	return wsTable[ch] != 0
-}
-
 func skipWSSlow(s string) string {
-	if len(s) == 0 || !isWSBySearchTable(s[0]) {
+	if len(s) == 0 || !wsSearchTable[s[0]] {
 		return s
 	}
 	for i := 1; i < len(s); i++ {
-		if !isWSBySearchTable(s[i]) {
+		if !wsSearchTable[s[i]] {
 			return s[i:]
 		}
 	}


### PR DESCRIPTION

## macos + arm64
before:
```text
goos: darwin
goarch: arm64
pkg: github.com/valyala/fastjson
cpu: Apple M2
BenchmarkParseTwitter/fastjson-get-8              497019             74978 ns/op        8422.71 MB/s           0 B/op          0 allocs/op
```

after:
```text
goos: darwin
goarch: arm64
pkg: github.com/valyala/fastjson
cpu: Apple M2
BenchmarkParseTwitter/fastjson-get-8              552360             65127 ns/op        9696.69 MB/s           0 B/op          0 allocs/op
```

1 - 9696.69/8422.71 = 15.1% faster.

## linux + amd64

before:
```text
goos: linux
goarch: amd64
pkg: github.com/valyala/fastjson
cpu: Intel(R) Core(TM) Ultra 7 265KF
BenchmarkParseTwitter/fastjson-get-20            2036187             17726 ns/op        35626.89 MB/s          0 B/op          0 allocs/op
```

after:
```text
goos: linux
goarch: amd64
pkg: github.com/valyala/fastjson
cpu: Intel(R) Core(TM) Ultra 7 265KF
BenchmarkParseTwitter/fastjson-get-20            2391160             15137 ns/op        41721.22 MB/s          0 B/op          0 allocs/op
```

17.1% faster

## modified code

```go
var wsSearchTable = func() [256]bool {
	var table [256]bool
	for _, c := range []byte{0x20, 0x0A, 0x09, 0x0D} {
		table[c] = true
	}
	return table
}()

func skipWSSlow(s string) string {
	if len(s) == 0 || !wsSearchTable[s[0]] {
		return s
	}
	for i := 1; i < len(s); i++ {
		if !wsSearchTable[s[i]] {
			return s[i:]
		}
	}
	return ""
}
```